### PR TITLE
JSONProtocol needs to import Transport constants

### DIFF
--- a/lib/Thrift/JSONProtocol.pm
+++ b/lib/Thrift/JSONProtocol.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 use Thrift;
 use Thrift::Protocol;
+use Thrift::Transport;
 use base qw(Thrift::Protocol Class::Accessor);
 
 use utf8;


### PR DESCRIPTION
TTransportException::END_OF_FILE isn't recognized in the standard path
